### PR TITLE
Potential fix for code scanning alert no. 325: Missing rate limiting

### DIFF
--- a/backend/src/routes/security.js
+++ b/backend/src/routes/security.js
@@ -374,6 +374,7 @@ router.post('/bulk-operations',
  */
 router.get('/health',
     authorize(['super_admin']),
+    RateLimiterService.createMiddleware({ rule: 'default' }),
     async (req, res) => {
         try {
             const health = {


### PR DESCRIPTION
Potential fix for [https://github.com/Mosleh92/exchange-platform-v3/security/code-scanning/325](https://github.com/Mosleh92/exchange-platform-v3/security/code-scanning/325)

To fix the issue, we will add rate limiting to the `/health` route. The `RateLimiterService.createMiddleware` method is already used elsewhere in the file (e.g., line 355), so we will reuse it to create a rate-limiting middleware for this route. We will configure the middleware with appropriate settings, such as a maximum number of requests per minute, to ensure that the route is protected against abuse.

Steps:
1. Add the rate-limiting middleware to the `/health` route.
2. Use the `RateLimiterService.createMiddleware` method to define the rate-limiting rule.
3. Ensure the middleware is applied before the route handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
