### PR TITLE
test: add roleAccess edge case tests

### DIFF
--- a/frontend/src/utils/roleAccess.test.js
+++ b/frontend/src/utils/roleAccess.test.js
@@ -1,5 +1,8 @@
-import { describe, it, expect } from '@jest/globals';
-import { hasAccess } from './roleAccess';
+import { describe, it, expect, jest } from '@jest/globals';
+
+jest.mock('../contexts/AuthContext', () => ({ AuthContext: {} }));
+
+import { hasAccess } from './roleAccess.js';
 
 describe('hasAccess', () => {
   it('returns true for allowed role', () => {
@@ -8,4 +11,11 @@ describe('hasAccess', () => {
   it('returns false for disallowed role', () => {
     expect(hasAccess({ role: 'user' }, ['admin'])).toBe(false);
   });
-}); 
+  it('returns true when user role is among multiple allowed roles', () => {
+    expect(hasAccess({ role: 'manager' }, ['admin', 'manager'])).toBe(true);
+  });
+  it('returns false when user lacks a role property', () => {
+    expect(hasAccess({}, ['admin'])).toBe(false);
+  });
+});
+


### PR DESCRIPTION
### **User description**
## Summary
- ensure hasAccess allows access when multiple roles are permitted
- cover case where user objects lack a role property

## Testing
- `npm test -- src/utils/roleAccess.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68920a119e9c832ea25cd555664cc85f


___

### **PR Type**
Tests


___

### **Description**
- Add edge case tests for `hasAccess` function

- Cover multiple allowed roles scenario

- Test user objects without role property

- Add Jest mock for AuthContext


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["hasAccess function"] --> B["Multiple roles test"]
  A --> C["Missing role property test"]
  D["Jest mock"] --> E["AuthContext mock"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>roleAccess.test.js</strong><dd><code>Add edge case tests for roleAccess</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/utils/roleAccess.test.js

<ul><li>Add Jest mock for AuthContext<br> <li> Add test for multiple allowed roles scenario<br> <li> Add test for user objects lacking role property<br> <li> Import jest from @jest/globals</ul>


</details>


  </td>
  <td><a href="https://github.com/Mosleh92/exchange-platform-v3/pull/75/files#diff-42f400d1a80eadb2b0b6f00abc1e5807260d553d87d5ae67544bf80c5525487f">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for role validation, including scenarios with multiple allowed roles and missing user roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->